### PR TITLE
Optimize images

### DIFF
--- a/components/post-header-info/post-header-info.tsx
+++ b/components/post-header-info/post-header-info.tsx
@@ -1,9 +1,9 @@
-import Image from 'next/image';
+import Image from "next/image";
 
-import { getFirstNKeywords } from '../../lib/keywords';
-import { categoriesArray } from '../../lib/categories';
+import { getFirstNKeywords } from "../../lib/keywords";
+import { categoriesArray } from "../../lib/categories";
 
-import styles from './post-header-info.module.scss';
+import styles from "./post-header-info.module.scss";
 
 type PostHeaderInfoProps = {
   postInfo: {
@@ -21,33 +21,40 @@ export default function PostHeaderInfo({
   className,
 }: PostHeaderInfoProps) {
   const datePublished = new Date(publishedAt).toLocaleDateString(undefined, {
-    year: 'numeric',
-    month: 'long',
+    year: "numeric",
+    month: "long",
   });
-  const [monthPublished, yearPublished] = datePublished.split(' ');
+  const [monthPublished, yearPublished] = datePublished.split(" ");
 
   const { color } = categoriesArray.find(
-    category => category.name.toLowerCase() === postCategory
+    (category) => category.name.toLowerCase() === postCategory
   ) || {
-    color: '',
+    color: "",
   };
 
   return (
     <div className={styles[className]}>
-      <div className={styles['post-info']}>
+      <div className={styles["post-info"]}>
         <ul className={styles.list}>
-          <li className={styles['avatar-container']}>
-            <Image src={authorImage} alt={`${authorName} avatar`} layout='fill' objectFit='cover' />
+          <li className={styles["avatar-container"]}>
+            <Image
+              src={`${authorImage}?&h=50&w=50&fit=crop&crop=center`}
+              alt={`${authorName} avatar`}
+              width={50}
+              height={50}
+              layout="fill"
+              objectFit="cover"
+            />
           </li>
           <li>{authorName}</li>
-          <li className={styles['date-published']}>
+          <li className={styles["date-published"]}>
             <span>&#183;</span>
-            <span className={styles['month-published']}>{monthPublished}</span>
+            <span className={styles["month-published"]}>{monthPublished}</span>
             <span>{yearPublished}</span>
           </li>
         </ul>
         <ul className={styles.keywords}>
-          {getFirstNKeywords(keywords, 2).map(keyword => (
+          {getFirstNKeywords(keywords, 2).map((keyword) => (
             <li className={`${styles[color]}`} key={keyword}>
               {keyword}
             </li>

--- a/components/post-header-info/post-header-info.tsx
+++ b/components/post-header-info/post-header-info.tsx
@@ -42,8 +42,6 @@ export default function PostHeaderInfo({
               alt={`${authorName} avatar`}
               width={50}
               height={50}
-              layout="fill"
-              objectFit="cover"
             />
           </li>
           <li>{authorName}</li>

--- a/components/post-header/post-header.tsx
+++ b/components/post-header/post-header.tsx
@@ -1,8 +1,8 @@
-import Image from 'next/image';
+import Image from "next/image";
 
-import PostHeaderInfo from '../post-header-info/post-header-info';
+import PostHeaderInfo from "../post-header-info/post-header-info";
 
-import styles from './post-header.module.scss';
+import styles from "./post-header.module.scss";
 
 type PostHeaderProps = {
   data: {
@@ -14,11 +14,22 @@ type PostHeaderProps = {
     keywords: string;
     imageUrl: string;
     imageAlt: string;
+    imageMetadata: SanityImageMetadata;
   };
 };
 
 export default function PostHeader({
-  data: { title, authorImage, authorName, category, publishedAt, keywords, imageUrl, imageAlt },
+  data: {
+    title,
+    authorImage,
+    authorName,
+    category,
+    publishedAt,
+    keywords,
+    imageUrl,
+    imageAlt,
+    imageMetadata,
+  },
 }: PostHeaderProps) {
   const postHeaderInfo = {
     authorImage,
@@ -29,13 +40,22 @@ export default function PostHeader({
   };
 
   return (
-    <div className={styles['post-header']}>
-      <div className={styles['header-wrapper-top']}>
-        <h1 className={styles['post-title']}>{title}</h1>
-        <PostHeaderInfo postInfo={postHeaderInfo} className='post-main' />
+    <div className={styles["post-header"]}>
+      <div className={styles["header-wrapper-top"]}>
+        <h1 className={styles["post-title"]}>{title}</h1>
+        <PostHeaderInfo postInfo={postHeaderInfo} className="post-main" />
       </div>
-      <div className={styles['image-container']}>
-        <Image src={imageUrl} alt={imageAlt} layout='fill' objectFit='cover'></Image>
+      <div className={styles["image-container"]}>
+        <Image
+          src={imageUrl}
+          alt={imageAlt}
+          width={imageMetadata.dimensions.width}
+          height={imageMetadata.dimensions.height}
+          blurDataURL={imageMetadata.lqip}
+          placeholder="blur"
+          layout="fill"
+          objectFit="cover"
+        ></Image>
       </div>
     </div>
   );

--- a/components/post-header/post-header.tsx
+++ b/components/post-header/post-header.tsx
@@ -49,8 +49,6 @@ export default function PostHeader({
         <Image
           src={imageUrl}
           alt={imageAlt}
-          width={imageMetadata.dimensions.width}
-          height={imageMetadata.dimensions.height}
           blurDataURL={imageMetadata.lqip}
           placeholder="blur"
           layout="fill"

--- a/components/post-preview/post-preview.tsx
+++ b/components/post-preview/post-preview.tsx
@@ -1,9 +1,9 @@
-import Link from 'next/link';
-import Image from 'next/image';
+import Link from "next/link";
+import Image from "next/image";
 
-import PostHeaderInfo from '../post-header-info/post-header-info';
+import PostHeaderInfo from "../post-header-info/post-header-info";
 
-import styles from './post-preview.module.scss';
+import styles from "./post-preview.module.scss";
 
 type PostPreviewProps = {
   post: PostPreview;
@@ -20,30 +20,36 @@ export default function PostPreview({ post, isFirst }: PostPreviewProps) {
   };
 
   return (
-    <div className={`${isFirst ? styles['top-post'] : ''}`}>
-      <div className={styles['post-preview']}>
-        <div className={styles['image-container']}>
+    <div className={`${isFirst ? styles["top-post"] : ""}`}>
+      <div className={styles["post-preview"]}>
+        <div className={styles["image-container"]}>
           <Link href={`/blog/${post.slug.current}`}>
             <a>
               <Image
                 src={post.featuredImage.asset.url}
                 alt={post.featuredImageAlt}
-                layout='fill'
-                objectFit='cover'
+                width={post.featuredImage.asset.metadata.dimensions.width}
+                height={post.featuredImage.asset.metadata.dimensions.height}
+                blurDataURL={post.featuredImage.asset.metadata.lqip}
+                objectFit="cover"
+                layout="fill"
+                placeholder="blur"
               />
             </a>
           </Link>
         </div>
-        <div className={styles['post-text']}>
+        <div className={styles["post-text"]}>
           <div>
             <Link href={`/blog/${post.slug.current}`}>
               <a>
-                <h3 className={styles['post-title']}>{post.title}</h3>
-                <p className={styles['post-description']}>{post.longDescription}</p>
+                <h3 className={styles["post-title"]}>{post.title}</h3>
+                <p className={styles["post-description"]}>
+                  {post.longDescription}
+                </p>
               </a>
             </Link>
           </div>
-          <PostHeaderInfo postInfo={postHeaderInfo} className='post-preview' />
+          <PostHeaderInfo postInfo={postHeaderInfo} className="post-preview" />
         </div>
       </div>
     </div>

--- a/components/post-preview/post-preview.tsx
+++ b/components/post-preview/post-preview.tsx
@@ -28,8 +28,6 @@ export default function PostPreview({ post, isFirst }: PostPreviewProps) {
               <Image
                 src={post.featuredImage.asset.url}
                 alt={post.featuredImageAlt}
-                width={post.featuredImage.asset.metadata.dimensions.width}
-                height={post.featuredImage.asset.metadata.dimensions.height}
                 blurDataURL={post.featuredImage.asset.metadata.lqip}
                 objectFit="cover"
                 layout="fill"

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,11 @@
+type SanityImageMetadata = {
+  dimensions: {
+    width: number;
+    height: number;
+  };
+  lqip: string;
+};
+
 type PostPreview = {
   title: string;
   slug: {
@@ -16,6 +24,7 @@ type PostPreview = {
   featuredImage: {
     asset: {
       url: string;
+      metadata: SanityImageMetadata;
     };
   };
   featuredImageAlt: string;
@@ -43,6 +52,7 @@ type PostMain = {
   featuredImage: {
     asset: {
       url: string;
+      metadata: SanityImageMetadata;
     };
   };
   featuredImageAlt: string;

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -18,11 +18,7 @@ const POST_SUMMARY_QUERY = `
   featuredImage {
     asset {
       url
-      metadata { 
-        dimensions {
-          width 
-          height
-        }
+      metadata {
         lqip
       }
     }
@@ -110,11 +106,7 @@ export const getPost = (slug: string) => {
           featuredImage {
             asset {
               url
-              metadata { 
-                dimensions {
-                  width 
-                  height
-                }
+              metadata {
                 lqip
               }
             }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,4 +1,36 @@
-import { gql, request } from 'graphql-request';
+import { gql, request } from "graphql-request";
+
+const POST_SUMMARY_QUERY = `
+  title
+  slug {
+    current
+  }
+  keywords
+  longDescription
+  author {
+    name
+    image {
+      asset {
+        url        
+      }
+    }
+  }
+  featuredImage {
+    asset {
+      url
+      metadata { 
+        dimensions {
+          width 
+          height
+        }
+        lqip
+      }
+    }
+  }
+  featuredImageAlt
+  category
+  publishedAt
+`;
 
 export const getAllPosts = () => {
   return request(
@@ -6,28 +38,7 @@ export const getAllPosts = () => {
     gql`
       query {
         allPost(sort: { publishedAt: DESC }) {
-          title
-          slug {
-            current
-          }
-          keywords
-          longDescription
-          author {
-            name
-            image {
-              asset {
-                url
-              }
-            }
-          }
-          featuredImage {
-            asset {
-              url
-            }
-          }
-          featuredImageAlt
-          category
-          publishedAt
+          ${POST_SUMMARY_QUERY}
         }
       }
     `
@@ -39,29 +50,11 @@ export const getPostsByCategory = (category: string) => {
     process.env.CMS_URL as string,
     gql`
       query {
-        allPost(where: { category: { eq: "${category}"} }) {        
-          title
-          slug {
-            current
-          }
-          keywords
-          longDescription
-          author {
-            name
-            image {
-              asset {
-                url
-              }
-            }
-          }
-          featuredImage {
-            asset {
-              url
-            }
-          }
-          featuredImageAlt
-          category
-          publishedAt
+        allPost(
+          where: { category: { eq: "${category}"} }
+          sort: { publishedAt: DESC }
+        ) {        
+          ${POST_SUMMARY_QUERY}
         }
       }
     `
@@ -117,6 +110,13 @@ export const getPost = (slug: string) => {
           featuredImage {
             asset {
               url
+              metadata { 
+                dimensions {
+                  width 
+                  height
+                }
+                lqip
+              }
             }
           }
           featuredImageAlt

--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,10 @@
 const nextConfig = {
   reactStrictMode: true,
   images: {
-    domains: ['cdn.sanity.io'],
+    domains: ["cdn.sanity.io"],
+  },
+  experimental: {
+    scrollRestoration: true,
   },
 };
 

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -8,7 +8,7 @@ import MetaHead from "../../components/meta-head/head";
 
 export default function BlogPost({ data }: PostsMain) {
   const post = data[0];
-  console.log(data);
+  
   const postHeaderData = {
     title: post.title,
     description: post.description,
@@ -19,6 +19,7 @@ export default function BlogPost({ data }: PostsMain) {
     keywords: post.keywords,
     imageUrl: post.featuredImage.asset.url,
     imageAlt: post.featuredImageAlt,
+    imageMetadata: post.featuredImage.asset.metadata
   };
 
   const postBodyData = {


### PR DESCRIPTION
- Optimize image loading for post previews and headers by using the `lqip` Sanity provides as the `blurDataURL` prop on Images.
- Limit author images to 50 x 50 cropped to center, using query params ([https://www.sanity.io/docs/image-urls](https://www.sanity.io/docs/image-urls))
- Add `scrollRestoration` to the config, so that when users use the back button the page will be at the previous scroll position