### PR TITLE
Adjust layout and maximize link area for blog posts

### DIFF
--- a/components/layout/layout.module.scss
+++ b/components/layout/layout.module.scss
@@ -21,4 +21,7 @@
     bottom: 0;
     overflow-x: scroll;
   }
+  @media screen and (max-width: 500px) {
+    padding: 6%;
+  }
 }

--- a/components/post-preview/post-preview.module.scss
+++ b/components/post-preview/post-preview.module.scss
@@ -35,6 +35,15 @@
   text-align: justify;
 }
 
+.text-wrapper {
+  flex-grow: 1;
+
+  a {
+    display: block;
+    height: 100%;
+  }
+}
+
 @media screen and (max-width: 1250px) {
   .post-preview {
     font-size: 0.9em;

--- a/components/post-preview/post-preview.tsx
+++ b/components/post-preview/post-preview.tsx
@@ -1,9 +1,9 @@
-import Link from "next/link";
-import Image from "next/image";
+import Link from 'next/link';
+import Image from 'next/image';
 
-import PostHeaderInfo from "../post-header-info/post-header-info";
+import PostHeaderInfo from '../post-header-info/post-header-info';
 
-import styles from "./post-preview.module.scss";
+import styles from './post-preview.module.scss';
 
 type PostPreviewProps = {
   post: PostPreview;
@@ -20,34 +20,32 @@ export default function PostPreview({ post, isFirst }: PostPreviewProps) {
   };
 
   return (
-    <div className={`${isFirst ? styles["top-post"] : ""}`}>
-      <div className={styles["post-preview"]}>
-        <div className={styles["image-container"]}>
+    <div className={`${isFirst ? styles['top-post'] : ''}`}>
+      <div className={styles['post-preview']}>
+        <div className={styles['image-container']}>
           <Link href={`/blog/${post.slug.current}`}>
             <a>
               <Image
                 src={post.featuredImage.asset.url}
                 alt={post.featuredImageAlt}
                 blurDataURL={post.featuredImage.asset.metadata.lqip}
-                objectFit="cover"
-                layout="fill"
-                placeholder="blur"
+                objectFit='cover'
+                layout='fill'
+                placeholder='blur'
               />
             </a>
           </Link>
         </div>
-        <div className={styles["post-text"]}>
-          <div>
+        <div className={styles['post-text']}>
+          <div className={styles['text-wrapper']}>
             <Link href={`/blog/${post.slug.current}`}>
               <a>
-                <h3 className={styles["post-title"]}>{post.title}</h3>
-                <p className={styles["post-description"]}>
-                  {post.longDescription}
-                </p>
+                <h3 className={styles['post-title']}>{post.title}</h3>
+                <p className={styles['post-description']}>{post.longDescription}</p>
               </a>
             </Link>
           </div>
-          <PostHeaderInfo postInfo={postHeaderInfo} className="post-preview" />
+          <PostHeaderInfo postInfo={postHeaderInfo} className='post-preview' />
         </div>
       </div>
     </div>

--- a/components/post-preview/post-preview.tsx
+++ b/components/post-preview/post-preview.tsx
@@ -21,10 +21,10 @@ export default function PostPreview({ post, isFirst }: PostPreviewProps) {
 
   return (
     <div className={`${isFirst ? styles['top-post'] : ''}`}>
-      <div className={styles['post-preview']}>
-        <div className={styles['image-container']}>
-          <Link href={`/blog/${post.slug.current}`}>
-            <a>
+      <Link href={`/blog/${post.slug.current}`}>
+        <a>
+          <div className={styles['post-preview']}>
+            <div className={styles['image-container']}>
               <Image
                 src={post.featuredImage.asset.url}
                 alt={post.featuredImageAlt}
@@ -33,21 +33,17 @@ export default function PostPreview({ post, isFirst }: PostPreviewProps) {
                 layout='fill'
                 placeholder='blur'
               />
-            </a>
-          </Link>
-        </div>
-        <div className={styles['post-text']}>
-          <div className={styles['text-wrapper']}>
-            <Link href={`/blog/${post.slug.current}`}>
-              <a>
+            </div>
+            <div className={styles['post-text']}>
+              <div className={styles['text-wrapper']}>
                 <h3 className={styles['post-title']}>{post.title}</h3>
                 <p className={styles['post-description']}>{post.longDescription}</p>
-              </a>
-            </Link>
+              </div>
+              <PostHeaderInfo postInfo={postHeaderInfo} className='post-preview' />
+            </div>
           </div>
-          <PostHeaderInfo postInfo={postHeaderInfo} className='post-preview' />
-        </div>
-      </div>
+        </a>
+      </Link>
     </div>
   );
 }


### PR DESCRIPTION
Why: 
- Categories menu was not aligned with post cards on mobile 
- Only image, title and description linked to the blog posts 

How: 
- Adjusted categories menu padding on mobile 
- Made entire post preview cards clickable