### PR TITLE
Tweak layout for large screens

### DIFF
--- a/components/featured-posts/featured-posts.module.scss
+++ b/components/featured-posts/featured-posts.module.scss
@@ -3,22 +3,16 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 23px 21px;
-  grid-auto-flow: row;
-  width: 83.3%;
-
-  /* @media screen and (max-width: 1000px) {
-    margin-top: 15em;
-  } */
-  @media screen and (max-width: 900px) {
-    width: 95%;
+  grid-auto-flow: row;  
+  width: 88%;
+  
+  @media screen and (max-width: 900px) {    
     column-gap: 18px;
   }
+  
   @media screen and (max-width: 750px) {
     grid-template-columns: 1fr;
-    margin: 1em auto;
-    width: 70%;
-  }
-  @media screen and (max-width: 500px) {
-    width: 88%;
-  }
+    margin: 1em auto;    
+    width: 100%;
+  }  
 }

--- a/components/featured-posts/featured-posts.module.scss
+++ b/components/featured-posts/featured-posts.module.scss
@@ -1,14 +1,14 @@
 .featured-posts {
-  margin: 18em auto 7em;
+  margin: 3.56em auto 7em;
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 23px 21px;
   grid-auto-flow: row;
   width: 83.3%;
 
-  @media screen and (max-width: 1000px) {
+  /* @media screen and (max-width: 1000px) {
     margin-top: 15em;
-  }
+  } */
   @media screen and (max-width: 900px) {
     width: 95%;
     column-gap: 18px;

--- a/components/header/header.module.scss
+++ b/components/header/header.module.scss
@@ -2,17 +2,35 @@
 @import '../../styles/utilities';
 
 .header {
-  min-height: 64px;
-  font-size: 1.25em;
-  margin-bottom: 9.4rem;
+  /* min-height: 64px; */
+  font-size: 1.25em;  
+  margin: 0 auto 9.4rem;
+  padding: 2em 0;
+  width: 83.8%;
+
+  /* @media screen and (max-width: 900px) {
+    width: 95%;    
+  }
+
+  @media screen and (max-width: 750px) {    
+    width: 70%;
+  } */
+
+  @media screen and (max-width: 500px) {
+    width: 88%;
+  }
+
+  @media screen and (min-width: 750px) {
+    width: auto;
+  }
 }
 
 .nav-main {
-  position: absolute;
+  /* position: absolute;
   top: 2em;
-  right: 2em;
+  right: 2em; */
   z-index: 4;
-  width: calc(100% - 4em);
+  /* width: calc(100% - 4em); */
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -81,11 +99,11 @@
     margin-bottom: 3em;
   }
 
-  .nav-main {
+  /* .nav-main {
     top: 2.5%;
     right: 5%;
     width: 90%;
-  }
+  } */
 
   .menu-toggle {
     height: 14px;
@@ -134,10 +152,11 @@
   .nav-mobile {
     background-color: $color-dark-gray;
     display: block;
-    position: absolute;
+    position: fixed;
     padding: 5%;
     width: 100vw;
     height: 100vh;
+    left: 0;
     top: -100vh;
     visibility: hidden;
     transition: all 0.5s cubic-bezier(0, 0.16, 0.78, 1);
@@ -186,8 +205,10 @@
 
   .header-wrapper {
     &.open {
-      .nav-main {
-        position: fixed;
+      .nav-main {                
+        a, button {
+          z-index: 10;
+        }
       }
 
       .nav-mobile {
@@ -196,7 +217,7 @@
         position: fixed;
       }
 
-      .menu-toggle {
+      .menu-toggle {                
         span {
           background-color: $color-pink;
           transition: transform 0.5s, background-color 0.2s;

--- a/components/header/header.module.scss
+++ b/components/header/header.module.scss
@@ -1,39 +1,24 @@
-@import '../../styles/variables';
-@import '../../styles/utilities';
+@import "../../styles/variables";
+@import "../../styles/utilities";
 
 .header {
-  /* min-height: 64px; */
-  font-size: 1.25em;  
-  margin: 0 auto 9.4rem;
+  width: 95%;
+  margin: 0 auto 6.25rem;
   padding: 2em 0;
-  width: 83.8%;
+  max-width: 1440px;
+  font-size: 1.25em;
 
-  /* @media screen and (max-width: 900px) {
-    width: 95%;    
-  }
-
-  @media screen and (max-width: 750px) {    
-    width: 70%;
-  } */
-
-  @media screen and (max-width: 500px) {
-    width: 88%;
-  }
-
-  @media screen and (min-width: 750px) {
-    width: auto;
+  @media screen and (max-width: 750px) {
+    width: 90%;    
+    padding: 1.2em 0;
   }
 }
 
 .nav-main {
-  /* position: absolute;
-  top: 2em;
-  right: 2em; */
-  z-index: 4;
-  /* width: calc(100% - 4em); */
   display: flex;
   justify-content: space-between;
   align-items: center;
+  z-index: 4;
 }
 
 .wrapper-nav-top {
@@ -98,12 +83,6 @@
   .header {
     margin-bottom: 3em;
   }
-
-  /* .nav-main {
-    top: 2.5%;
-    right: 5%;
-    width: 90%;
-  } */
 
   .menu-toggle {
     height: 14px;
@@ -205,8 +184,9 @@
 
   .header-wrapper {
     &.open {
-      .nav-main {                
-        a, button {
+      .nav-main {
+        a,
+        button {
           z-index: 10;
         }
       }
@@ -217,7 +197,7 @@
         position: fixed;
       }
 
-      .menu-toggle {                
+      .menu-toggle {
         span {
           background-color: $color-pink;
           transition: transform 0.5s, background-color 0.2s;
@@ -236,7 +216,7 @@
 
 @media screen and (max-width: 500px) {
   .header {
-    margin-bottom: 2.625em;
+    margin-bottom: 1.5em;
   }
   .nav-logo > * {
     width: 79px;

--- a/components/layout/layout.module.scss
+++ b/components/layout/layout.module.scss
@@ -1,9 +1,6 @@
 @import '../../styles/variables';
 
 .layout {
-  width: 95%;
-  max-width: 1440px;
-  margin: auto;
   position: relative;  
 }
 
@@ -13,24 +10,31 @@
   flex-direction: column;
 }
 
-.categories-container {
-  /* position: absolute;
-  top: -8.8em;
-  margin: 0 2em; */
-  order: -1;
-  display: flex;
-
-  /* @media screen and (max-width: 1000px) {
-    top: -7.5em;
-  } */
+.content {
+  width: 95%;
+  max-width: 1440px;
+  margin: auto;
 
   @media screen and (max-width: 750px) {
+    width: 90%;
+  }
+}
+
+.categories-container {
+  order: -1;
+  display: flex;
+  width: 95%;
+  max-width: 1440px;
+  margin: auto;
+  
+  @media screen and (max-width: 750px) {
+    position: sticky;
+    width: 100%;
+    bottom: 0;    
     order: 1;
     background-color: $color-smoked-white;
     padding: 1em;
     margin: 1em 0;
-    position: sticky;
-    /* bottom: 0; */
     overflow-x: scroll;
   }
 

--- a/components/layout/layout.module.scss
+++ b/components/layout/layout.module.scss
@@ -1,26 +1,39 @@
 @import '../../styles/variables';
 
+.layout {
+  width: 95%;
+  max-width: 1440px;
+  margin: auto;
+  position: relative;  
+}
+
 .main-wrapper {
   position: relative;
+  display: flex;
+  flex-direction: column;
 }
 
 .categories-container {
-  position: absolute;
+  /* position: absolute;
   top: -8.8em;
-  margin: 0 2em;
+  margin: 0 2em; */
+  order: -1;
+  display: flex;
 
-  @media screen and (max-width: 1000px) {
+  /* @media screen and (max-width: 1000px) {
     top: -7.5em;
-  }
+  } */
 
   @media screen and (max-width: 750px) {
+    order: 1;
     background-color: $color-smoked-white;
     padding: 1em;
     margin: 1em 0;
     position: sticky;
-    bottom: 0;
+    /* bottom: 0; */
     overflow-x: scroll;
   }
+
   @media screen and (max-width: 500px) {
     padding: 6%;
   }

--- a/components/layout/layout.module.scss
+++ b/components/layout/layout.module.scss
@@ -1,9 +1,5 @@
 @import '../../styles/variables';
 
-.layout {
-  position: relative;  
-}
-
 .main-wrapper {
   position: relative;
   display: flex;

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -17,15 +17,15 @@ export default function Layout({ children, showCategories }: LayoutProps) {
       <div className={styles["layout"]}>
         <Header />
         <div className={styles["main-wrapper"]}>
-          <div className="content">{children}</div>
+          <div className={styles["content"]}>{children}</div>
           {showCategories && (
             <div className={styles["categories-container"]}>
               <Categories />
             </div>
           )}
         </div>
-        <Footer />
       </div>
+      <Footer />
     </>
   );
 }

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -14,7 +14,7 @@ export default function Layout({ children, showCategories }: LayoutProps) {
   return (
     <>
       <MetaHead />
-      <div className="layout">
+      <div className={styles["layout"]}>
         <Header />
         <div className={styles["main-wrapper"]}>
           <div className="content">{children}</div>

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -14,17 +14,16 @@ export default function Layout({ children, showCategories }: LayoutProps) {
   return (
     <>
       <MetaHead />
-      <div className={styles["layout"]}>
-        <Header />
-        <div className={styles["main-wrapper"]}>
-          <div className={styles["content"]}>{children}</div>
-          {showCategories && (
-            <div className={styles["categories-container"]}>
-              <Categories />
-            </div>
-          )}
-        </div>
-      </div>
+
+      <Header />
+      <main className={styles["main-wrapper"]}>
+        <section className={styles["content"]}>{children}</section>
+        {showCategories && (
+          <section className={styles["categories-container"]}>
+            <Categories />
+          </section>
+        )}
+      </main>
       <Footer />
     </>
   );

--- a/components/post-body/post-body.module.scss
+++ b/components/post-body/post-body.module.scss
@@ -10,7 +10,7 @@
   @media screen and (max-width: 500px) {
     margin-top: 2.69em;
     margin-bottom: 3.82em;
-    width: min(90%, 400px);
+    width: min(100%, 400px);
   }
 }
 
@@ -153,7 +153,7 @@
     }
 
     @media screen and (max-width: 750px) {
-      padding: 20px;
+      padding: 0 20px;
     }
   }
 }

--- a/components/post-header/post-header.module.scss
+++ b/components/post-header/post-header.module.scss
@@ -19,6 +19,7 @@
 .image-container {
   position: relative;
   height: 34.7vw;
+  max-height: 490px;
   width: 100%;
   border-radius: 19.41px;
   overflow: hidden;
@@ -46,7 +47,7 @@
 @media screen and (max-width: 500px) {
   .post-header {
     gap: 43px;
-    width: min(90%, 400px);
+    width: min(100%, 400px);
   }
 
   .header-wrapper-top {


### PR DESCRIPTION
Why:
 - On large screens, everything was looking really huge.

How:
 - Set a max width of 1440px for the site's content.
 - Also simplify some of the CSS: use `order` to switch the position of the posts and categories, instead of `absolute` positioning.