### PR TITLE
Use optional image in post headers

### DIFF
--- a/components/post-header/post-header.tsx
+++ b/components/post-header/post-header.tsx
@@ -15,6 +15,8 @@ type PostHeaderProps = {
     imageUrl: string;
     imageAlt: string;
     imageMetadata: SanityImageMetadata;
+    headerImageUrl?: string;
+    headerImageMetadata: SanityImageMetadata;
   };
 };
 
@@ -29,6 +31,8 @@ export default function PostHeader({
     imageUrl,
     imageAlt,
     imageMetadata,
+    headerImageUrl,
+    headerImageMetadata,
   },
 }: PostHeaderProps) {
   const postHeaderInfo = {
@@ -39,6 +43,11 @@ export default function PostHeader({
     keywords,
   };
 
+  const image = {
+    url: headerImageUrl || imageUrl,
+    metadata: imageMetadata || headerImageMetadata,
+  };
+
   return (
     <div className={styles["post-header"]}>
       <div className={styles["header-wrapper-top"]}>
@@ -47,9 +56,9 @@ export default function PostHeader({
       </div>
       <div className={styles["image-container"]}>
         <Image
-          src={imageUrl}
+          src={image.url}
           alt={imageAlt}
-          blurDataURL={imageMetadata.lqip}
+          blurDataURL={image.metadata.lqip}
           placeholder="blur"
           layout="fill"
           objectFit="cover"

--- a/index.d.ts
+++ b/index.d.ts
@@ -55,6 +55,12 @@ type PostMain = {
       metadata: SanityImageMetadata;
     };
   };
+  postHeaderImage: {
+    asset: {
+      url: string;
+      metadata: SanityImageMetadata;
+    };
+  };
   featuredImageAlt: string;
   category: string;
   publishedAt: string;

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -111,6 +111,14 @@ export const getPost = (slug: string) => {
               }
             }
           }
+          postHeaderImage {
+            asset {
+              url
+              metadata {
+                lqip
+              }
+            }
+          }
           featuredImageAlt
           category
           publishedAt

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -16,6 +16,8 @@ export default function BlogPost({ data }: PostsMain) {
     category: post.category,
     publishedAt: post.publishedAt,
     keywords: post.keywords,
+    headerImageUrl: post.postHeaderImage?.asset?.url,
+    headerImageMetadata: post.postHeaderImage?.asset?.metadata,
     imageUrl: post.featuredImage.asset.url,
     imageAlt: post.featuredImageAlt,
     imageMetadata: post.featuredImage.asset.metadata,


### PR DESCRIPTION
Why:
 - New field on the CMS with an optional post header image.

How:
 - Update queries, and use the new data. Fallback to the normal featured image.