### PR TITLE
Fix internal Links

### DIFF
--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -1,14 +1,16 @@
-import styles from './button.module.scss';
+/* eslint-disable react/display-name */
+import { forwardRef, Ref, } from "react";
+import styles from "./button.module.scss";
 
 export enum BUTTON_COLORS {
-  Pistachio = 'pistachio',
-  Green = 'green',
-  Violet = 'violet',
-  White = 'white',
-  Pink = 'pink',
-  Orange = 'orange',
-  TransparentLight = 'transparent-light',
-  TransparentDark = 'transparent-dark',
+  Pistachio = "pistachio",
+  Green = "green",
+  Violet = "violet",
+  White = "white",
+  Pink = "pink",
+  Orange = "orange",
+  TransparentLight = "transparent-light",
+  TransparentDark = "transparent-dark",
 }
 
 type ButtonProps = {
@@ -20,24 +22,34 @@ type ButtonProps = {
   target?: string;
 };
 
-export const Button = ({
-  children,
-  className = '',
-  buttonColor,
-  href = '',
-  rel = '',
-  target = '',
-}: ButtonProps) => {
-  return (
-    <a
-      href={href}
-      rel={rel}
-      target={target}
-      className={`${styles.button} ${styles[buttonColor]} ${className && styles[className]}`}
-    >
-      {children}
-    </a>
-  );
-};
+const Button = forwardRef(
+  (
+    {
+      children,
+      className = "",
+      buttonColor,
+      href = "",
+      rel = "",
+      target = "",
+      ...props
+    }: ButtonProps,
+    ref: Ref<HTMLAnchorElement>
+  ) => {
+    return (
+      <a
+        href={href}
+        rel={rel}
+        ref={ref}
+        target={target}
+        className={`${styles.button} ${styles[buttonColor]} ${
+          className && styles[className]
+        }`}
+        {...props}
+      >
+        {children}
+      </a>
+    );
+  }
+);
 
 export default Button;

--- a/components/categories/categories.tsx
+++ b/components/categories/categories.tsx
@@ -1,13 +1,13 @@
-import Link from 'next/link';
+import Link from "next/link";
 
-import Button from '../button/button';
-import { categoriesArray } from '../../lib/categories';
+import Button from "../button/button";
+import { categoriesArray } from "../../lib/categories";
 
-import styles from './categories.module.scss';
+import styles from "./categories.module.scss";
 
 export default function Categories() {
   return (
-    <div className={styles['categories']}>
+    <div className={styles["categories"]}>
       {categoriesArray.map(({ name, color, href }) => (
         <Link href={href} key={name} passHref>
           <Button buttonColor={color}>{name}</Button>


### PR DESCRIPTION
Why:
 - Button used as internal link was rendering a normal anchor element, not using `next/router`.

How:
 - Change `Button` into a forward ref component, passing all props to it's elements.