### PR TITLE
Add Twitter meta Card tag

### DIFF
--- a/components/meta-head/head.tsx
+++ b/components/meta-head/head.tsx
@@ -29,6 +29,8 @@ export default function MetaHead({
       />
       <meta name="og:image" content={meta.image} />
       <meta name="twitter:image" content={meta.image} />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={meta.title} />
       <meta name="description" content={meta.description} />
       <meta name="og:description" content={meta.description} />
       <meta name="twitter:description" content={meta.description} />


### PR DESCRIPTION
Why:
* In order to have posts previews on Twitter, we need to specify a
  "twitter:card" meta tag

How:
* Adding a meta tag for "twitter:card" set to "summary_large_image"
* Adding a meta tag for "twitter:title" set to the post's title
