### PR TITLE
Inject a Div when rendering a table

### DIFF
--- a/components/post-body/post-body.module.scss
+++ b/components/post-body/post-body.module.scss
@@ -220,9 +220,9 @@
   td {
     text-align: center;
     padding: 4px 12px;
-    
+
     @media screen and (min-width: 750px) {
-      padding: 4px 8px;      
+      padding: 4px 8px;
     }
   }
 

--- a/components/post-body/post-body.module.scss
+++ b/components/post-body/post-body.module.scss
@@ -201,15 +201,14 @@
   }
 
   table {
-    display: block;
-    overflow: scroll;
+    width: 100%;
     border-collapse: collapse;
     margin-bottom: 2rem;
+  }
 
-    @media screen and (min-width: 750px) {
-      display: table;
-      min-width: unset;
-    }
+  .table-container {
+    display: block;
+    overflow: scroll;
   }
 
   th {

--- a/components/post-body/post-body.tsx
+++ b/components/post-body/post-body.tsx
@@ -41,12 +41,10 @@ export default function PostBody({ data: { body } }: PostBodyProps) {
               </code>
             );
           },
-          table({children, ...props}) {
+          table({ children }) {
             return (
               <div className={styles["table-container"]}>
-                <table>
-                  {children}
-                </table>
+                <table>{children}</table>
               </div>
             );
           },

--- a/components/post-body/post-body.tsx
+++ b/components/post-body/post-body.tsx
@@ -41,6 +41,15 @@ export default function PostBody({ data: { body } }: PostBodyProps) {
               </code>
             );
           },
+          table({children, ...props}) {
+            return (
+              <div className={styles["table-container"]}>
+                <table>
+                  {children}
+                </table>
+              </div>
+            );
+          },
         }}
       >
         {body}


### PR DESCRIPTION
Why:
 - When rendering a table we want to make it responsive. To make a `table` responsive we need to wrap it around a `div`.

How:
 - Using `react-markdown` render to inject a div when rendering a table.
 - Make the div horizontally scrollable.