### PR TITLE
Update goat counter script to distinguish page views from the site

### DIFF
--- a/components/meta-head/head.tsx
+++ b/components/meta-head/head.tsx
@@ -1,4 +1,5 @@
 import Head from "next/head";
+import { useEffect } from "react";
 
 const SOCIAL_IMG_SRC =
   "https://uploads-ssl.webflow.com/625fdbdd8d4bae7f7da9b1ba/627297235701e55b099f859e_meta-image.png";
@@ -17,6 +18,13 @@ export default function MetaHead({
     description: description || "Finiam's blog",
     image: image || SOCIAL_IMG_SRC,
   };
+
+  useEffect(() => {
+    window.goatcounter = {
+      // eslint-disable-next-line no-restricted-globals
+      path: () => `${location.host}${location.pathname}`,
+    };
+  }, []);
 
   return (
     <Head>

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,0 +1,7 @@
+export declare global {
+  interface Window {
+    goatcounter: {
+      path: () => string
+    }
+  }
+}


### PR DESCRIPTION
Why:
* We want to be able to distinguish views from the site from views from
  the blog. Since they are in different subdomains, GoatCounter was
  merging the views into the `/` path

How:
* Using a `useEffect` to update the GoatCounter `path` to include the
  full path. This is so we can distinguish between visits to the site
  and visits to the blog
* Adding a `globals.d.ts` to include the type for goatcounter
