### PR TITLE
Replace GoatCounter script with specific code

### DIFF
--- a/components/meta-head/head.tsx
+++ b/components/meta-head/head.tsx
@@ -1,5 +1,4 @@
 import Head from "next/head";
-import { useEffect } from "react";
 
 const SOCIAL_IMG_SRC =
   "https://uploads-ssl.webflow.com/625fdbdd8d4bae7f7da9b1ba/627297235701e55b099f859e_meta-image.png";
@@ -18,13 +17,6 @@ export default function MetaHead({
     description: description || "Finiam's blog",
     image: image || SOCIAL_IMG_SRC,
   };
-
-  useEffect(() => {
-    window.goatcounter = {
-      // eslint-disable-next-line no-restricted-globals
-      path: () => `${location.host}${location.pathname}`,
-    };
-  }, []);
 
   return (
     <Head>
@@ -45,7 +37,7 @@ export default function MetaHead({
       <meta name="image" property="og:image" content={meta.image} />
       <meta property="og:description" content={meta.description} />
       <script
-        data-goatcounter="https://finiam.goatcounter.com/count"
+        data-goatcounter="https://blogfiniam.goatcounter.com/count"
         async
         src="//gc.zgo.at/count.js"
       />

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,7 +1,0 @@
-export declare global {
-  interface Window {
-    goatcounter: {
-      path: () => string
-    }
-  }
-}


### PR DESCRIPTION
Why:
* Instead of trying to merge all the page views from the site and the
  blog into the same GoatCounter site, we decided to have one code for
  each

How:
* Removing the `globals.d.ts` file as it is no longer needed
* Removing the `useEffect` call used to update the `window`
* Replacing the `goatcounter` script with the new code from GoatCounter
