### PR TITLE
Add figcaption to images that have a Title

### DIFF
--- a/components/post-body/post-body.module.scss
+++ b/components/post-body/post-body.module.scss
@@ -114,6 +114,12 @@
     width: auto;
   }
 
+  figcaption {
+    margin-top: -22px;
+    font-size: 16px;
+    text-align: center;
+  }
+
   video {
     width: auto;
   }
@@ -124,6 +130,7 @@
 
   a {
     color: $color-green;
+    text-decoration: underline;
 
     overflow-wrap: break-word;
   }

--- a/components/post-body/post-body.tsx
+++ b/components/post-body/post-body.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @next/next/no-img-element */
 /* eslint-disable react/no-unstable-nested-components */
 import ReactMarkdown from "react-markdown";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
@@ -47,6 +48,18 @@ export default function PostBody({ data: { body } }: PostBodyProps) {
                 <table>{children}</table>
               </div>
             );
+          },
+          img({ src, alt, title }) {
+            if (title) {
+              return (
+                <figure>
+                  <img src={src} alt={alt} title={title} />
+                  <figcaption>{title}</figcaption>
+                </figure>
+              );
+            }
+
+            return <img src={src} alt={alt} />;
           },
         }}
       >


### PR DESCRIPTION
Why:
 - In markdown, we can only specify a title for an image (besides the alt). Many processors consider this title to be the `figcaption`. This PR makes that change to our version.
 - Links in the text are not very different from the actual text, so we're making them underlined by default.

How:
 - When the processor sees an `img` from the markdown structure, it checks if it has a title or not. If it has, then it adds a `figcaption`, else does nothing and just renders the image.
 - Underlining `a` tags for better distinction.

Captions
![Screenshot 2023-02-16 at 14 27 16](https://user-images.githubusercontent.com/25623039/219396765-3958f63d-cf21-4871-8dbc-1bbf2f3d9804.png)

Before
![Screenshot 2023-02-16 at 14 33 31](https://user-images.githubusercontent.com/25623039/219396560-85e04507-4919-4465-9050-aa64ce56bc40.png)

After
![Screenshot 2023-02-16 at 14 33 22](https://user-images.githubusercontent.com/25623039/219396501-174378aa-dedd-4c4c-9db3-b03136fb07a4.png)
