### PR TITLE
Fix iframe element display

### DIFF
--- a/components/post-body/post-body.module.scss
+++ b/components/post-body/post-body.module.scss
@@ -125,7 +125,7 @@
   }
 
   iframe {
-    width: auto;
+    width: 100%;
   }
 
   a {

--- a/components/post-body/post-body.tsx
+++ b/components/post-body/post-body.tsx
@@ -61,6 +61,13 @@ export default function PostBody({ data: { body } }: PostBodyProps) {
 
             return <img src={src} alt={alt} />;
           },
+          iframe({ title, ...props }) {
+            return (
+              <div>
+                <iframe title={title} {...props} />
+              </div>
+            );
+          },
         }}
       >
         {body}


### PR DESCRIPTION
Why:
 - Iframes like inline videos were badly displayed.

How:
 - This adds a `div` around the iframe, so it can keep the same width as the rest of the blog content.

Before
![Screenshot 2023-02-16 at 15 18 08](https://user-images.githubusercontent.com/25623039/219408170-7070c83b-df7a-4e51-a338-66f49792107f.png)

After
![Screenshot 2023-02-16 at 15 17 52](https://user-images.githubusercontent.com/25623039/219408227-ef9ca87b-f1cb-42fb-8362-97d6e30d8afa.png)
