### PR TITLE
Add RSS feed for development and design categories

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -11,7 +11,7 @@ const POST_SUMMARY_QUERY = `
     name
     image {
       asset {
-        url        
+        url
       }
     }
   }
@@ -48,7 +48,7 @@ export const getPostsByCategory = (category: string) =>
       allPost(
         where: { category: { eq: "${category}"} }
         sort: { publishedAt: DESC }
-      ) {        
+      ) {
         ${POST_SUMMARY_QUERY}
       }
     }
@@ -86,7 +86,7 @@ export const getPost = (slug: string) =>
     process.env.CMS_URL as string,
     gql`
     query {
-      allPost(where: { slug: { current: { eq: "${slug}" } } }) {        
+      allPost(where: { slug: { current: { eq: "${slug}" } } }) {
         title
         description
         keywords

--- a/lib/rss-feed.ts
+++ b/lib/rss-feed.ts
@@ -20,6 +20,7 @@ type Post = {
       url: string;
     };
   };
+  category: string;
   publishedAt: string;
 };
 
@@ -51,7 +52,27 @@ const generateRssFeed = async (posts: Post[]) => {
       json: `${siteURL}/rss/feed.json`,
       atom: `${siteURL}/rss/atom.xml`,
     },
+    author,
+  });
 
+  const devFeed = new Feed({
+    title: "Finiam's blog",
+    description: "This is Finiam's blog!",
+    id: `${siteURL}/`,
+    link: `${siteURL}/`,
+    language: "en",
+    image:
+      "https://uploads-ssl.webflow.com/625fdbdd8d4bae7f7da9b1ba/627297235701e55b099f859e_meta-image.png",
+    favicon: `${siteURL}/assets/favicon.svg`,
+    copyright: `All rights reserved ${date.getFullYear()}, Finiam`,
+    updated: date,
+    generator: "Feed for Node.js",
+    feed: `${siteURL}/rss/devfeed.xml`,
+    feedLinks: {
+      rss2: `${siteURL}/rss/devfeed.xml`,
+      json: `${siteURL}/rss/devfeed.json`,
+      atom: `${siteURL}/rss/devatom.xml`,
+    },
     author,
   });
 
@@ -67,12 +88,29 @@ const generateRssFeed = async (posts: Post[]) => {
       contributor: [author],
       date: new Date(post.publishedAt),
     });
+
+    if (post.category === "design" || post.category === "development") {
+      devFeed.addItem({
+        title: post.title,
+        id: url,
+        link: url,
+        description: post.longDescription,
+        author: [{ name: post.author.name }],
+        contributor: [author],
+        date: new Date(post.publishedAt),
+      });
+    }
   });
 
   fs.mkdirSync("./public/rss", { recursive: true });
   fs.writeFileSync("./public/rss/feed.xml", feed.rss2());
   fs.writeFileSync("./public/rss/atom.xml", feed.atom1());
   fs.writeFileSync("./public/rss/feed.json", feed.json1());
+
+  fs.mkdirSync("./public/rss", { recursive: true });
+  fs.writeFileSync("./public/rss/devfeed.xml", devFeed.rss2());
+  fs.writeFileSync("./public/rss/devatom.xml", devFeed.atom1());
+  fs.writeFileSync("./public/rss/devfeed.json", devFeed.json1());
 };
 
 export default generateRssFeed;


### PR DESCRIPTION
Why:
* [daily.dev](https://daily.dev) requested a tech only RSS feed so that they could show our
  posts in their aggregator

How:
* Adding `devfeed.xml`, `devatom.xml`, `devfeed.json` that only contain
  posts with `development` or `design` category
