### PR TITLE
Prevent left padding on code blocks

### DIFF
--- a/components/post-body/post-body.module.scss
+++ b/components/post-body/post-body.module.scss
@@ -173,6 +173,10 @@
     white-space: break-spaces;
   }
 
+  div > code {
+    padding-left: 0px;
+  }
+
   pre {
     display: block;
     padding: 20px 0;


### PR DESCRIPTION
Why:
* When using code blocks, there was a `padding-left: 8px` being applied
  to the first line of the code block

How:
* Adding a CSS rule to remove the `padding-left` from `code` elements
  that have a `div` parent

Before:
<img width="472" alt="image" src="https://user-images.githubusercontent.com/2940022/224480740-1ddbc029-4de9-4b56-990b-fa967b094337.png">

After:
<img width="491" alt="image" src="https://user-images.githubusercontent.com/2940022/224480762-4747f3ee-99d5-4ae3-b6c8-621e662d10b8.png">

