### PR TITLE
Add post image to RSS feeds

### DIFF
--- a/lib/rss-feed.ts
+++ b/lib/rss-feed.ts
@@ -83,6 +83,7 @@ const generateRssFeed = async (posts: Post[]) => {
       title: post.title,
       id: url,
       link: url,
+      image: post.featuredImage.asset.url,
       description: post.longDescription,
       author: [{ name: post.author.name }],
       contributor: [author],
@@ -93,6 +94,7 @@ const generateRssFeed = async (posts: Post[]) => {
       devFeed.addItem({
         title: post.title,
         id: url,
+        image: post.featuredImage.asset.url,
         link: url,
         description: post.longDescription,
         author: [{ name: post.author.name }],


### PR DESCRIPTION
Why:
* In case RSS consumers want to use the featured image from the post
  instead of the default finiam hero page. In particular, daily.dev accepted
  our RSS feed and it is now showing our posts.
* With this change, hopefully, future posts will show the featured image instead

How:
* Adding an `image` entry to the RSS feed that points to the featured
  image of each post


Example:
<img width="1111" alt="image" src="https://user-images.githubusercontent.com/2940022/226643569-af45cbce-67eb-47f0-b0b5-92ac9df706c5.png">

