### PR TITLE
Add a `key` attribute to the `meta` tag for `og:image`

### DIFF
--- a/components/meta-head/head.tsx
+++ b/components/meta-head/head.tsx
@@ -18,8 +18,6 @@ export default function MetaHead({
     image: image || SOCIAL_IMG_SRC,
   };
 
-  console.log(meta);
-
   return (
     <Head>
       <title>{meta.title}</title>
@@ -36,7 +34,12 @@ export default function MetaHead({
       <meta name="twitter:description" content={meta.description} />
       <meta property="og:title" content={meta.title} />
       <meta property="og:image" key="unnamed og:image" content={meta.image} />
-      <meta name="image" property="og:image" key="named og:image" content={meta.image} />
+      <meta
+        name="image"
+        property="og:image"
+        key="named og:image"
+        content={meta.image}
+      />
       <meta property="og:description" content={meta.description} />
       <script
         data-goatcounter="https://blogfiniam.goatcounter.com/count"

--- a/components/meta-head/head.tsx
+++ b/components/meta-head/head.tsx
@@ -18,6 +18,8 @@ export default function MetaHead({
     image: image || SOCIAL_IMG_SRC,
   };
 
+  console.log(meta);
+
   return (
     <Head>
       <title>{meta.title}</title>
@@ -27,14 +29,14 @@ export default function MetaHead({
         name="keywords"
         content="blog, finiam, fintech, design, development, startup, team, agency, digital, software, development"
       />
+      <meta name="description" content={meta.description} />
       <meta name="twitter:image" content={meta.image} />
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:title" content={meta.title} />
-      <meta name="description" content={meta.description} />
       <meta name="twitter:description" content={meta.description} />
       <meta property="og:title" content={meta.title} />
-      <meta property="og:image" content={meta.image} />
-      <meta name="image" property="og:image" content={meta.image} />
+      <meta property="og:image" key="unnamed og:image" content={meta.image} />
+      <meta name="image" property="og:image" key="named og:image" content={meta.image} />
       <meta property="og:description" content={meta.description} />
       <script
         data-goatcounter="https://blogfiniam.goatcounter.com/count"


### PR DESCRIPTION
Why:
* Post previews were showing the Hero image of our site, that is the
  fallback image when none is provided, even when the post has a image
* This is happening due to using the `MetaHead` component inside the
  `Layout` component and also in the `[slug].tsx` file responsible for
  rendering the indiviual post pages. The posts pages use the `Layout`
  component and also call the `MetaHead` component with the post
  appropriate values. This causes the `meta` tags to be added twice to
  the rendered page. [Next.JS docs](https://nextjs.org/docs/api-reference/next/head)
  provide a way to prevent this

How:
* Adding a `key` attribute to the `og:image` meta tags to prevent
  duplicate `meta` tags
