### PR TITLE
Style lists in body content

### DIFF
--- a/components/post-body/post-body.module.scss
+++ b/components/post-body/post-body.module.scss
@@ -139,10 +139,18 @@
     list-style-type: disc;
   }
 
+  ul ul {
+    list-style-type: circle;
+  }
+
   li {
-    padding-left: 1rem;
+    margin-left: 1.25rem;
     margin-bottom: 1rem;
     margin-top: 1rem;
+
+    ul, ol {
+      margin-left: 1.25rem;
+    }
   }
 
   li::marker {


### PR DESCRIPTION
Why:
 - Previously list items were being rendered before the text block.
 - This PR makes them render at the same level then the text, and then have a successive indentation.

How:
 - Give `margin-left` instead of padding.
 - Also render a different bullet point for nested lists.

Before
![Screenshot 2023-04-28 at 10 35 28](https://user-images.githubusercontent.com/25623039/235161445-d0c10cf6-2ad0-4e29-a87c-31208545224f.png)

Now
![Screenshot 2023-04-28 at 14 32 45](https://user-images.githubusercontent.com/25623039/235161513-84be527a-f916-4740-b6cd-711d4bef4eb0.png)