### PR TITLE
Fix duplicated and keywords meta tags

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,11 +1,11 @@
 {
   "plugins": ["stylelint-order", "stylelint-prettier", "stylelint-scss"],
-  "extends": ["stylelint-config-prettier"],  
+  "extends": ["stylelint-config-prettier"],
   "rules": {
     "prettier/prettier": true,
     "max-nesting-depth": 4,
     "indentation": 2,
-    "order/order": ["custom-properties", "declarations"],    
+    "order/order": ["custom-properties", "declarations"],
     "order/properties-order": [
       {
         "emptyLineBefore": "never",

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -3,7 +3,6 @@ import Footer from "../footer/footer";
 import Categories from "../categories/categories";
 
 import styles from "./layout.module.scss";
-import MetaHead from "../meta-head/head";
 
 type LayoutProps = {
   children: React.ReactNode;
@@ -13,8 +12,6 @@ type LayoutProps = {
 export default function Layout({ children, showCategories }: LayoutProps) {
   return (
     <>
-      <MetaHead />
-
       <Header />
       <main className={styles["main-wrapper"]}>
         <section className={styles.content}>{children}</section>

--- a/components/meta-head/head.tsx
+++ b/components/meta-head/head.tsx
@@ -18,7 +18,9 @@ export default function MetaHead({
     title: title || "Blog - Finiam",
     description: description || "Finiam's blog",
     image: image || SOCIAL_IMG_SRC,
-    keywords: keywords || "blog, finiam, fintech, design, development, startup, team, agency, digital, software, development, web3, blockchain, defi",
+    keywords:
+      keywords ||
+      "blog, finiam, fintech, design, development, startup, team, agency, digital, software, development, web3, blockchain, defi",
   };
 
   return (

--- a/components/meta-head/head.tsx
+++ b/components/meta-head/head.tsx
@@ -7,15 +7,18 @@ export default function MetaHead({
   title,
   description,
   image,
+  keywords,
 }: {
   title?: string;
   description?: string;
   image?: string;
+  keywords?: string;
 }) {
   const meta = {
     title: title || "Blog - Finiam",
     description: description || "Finiam's blog",
     image: image || SOCIAL_IMG_SRC,
+    keywords: keywords || "blog, finiam, fintech, design, development, startup, team, agency, digital, software, development, web3, blockchain, defi",
   };
 
   return (
@@ -23,10 +26,7 @@ export default function MetaHead({
       <title>{meta.title}</title>
 
       <link rel="icon" href="/assets/favicon.svg" />
-      <meta
-        name="keywords"
-        content="blog, finiam, fintech, design, development, startup, team, agency, digital, software, development"
-      />
+      <meta name="keywords" content={meta.keywords} />
       <meta name="description" content={meta.description} />
       <meta name="twitter:image" content={meta.image} />
       <meta name="twitter:card" content="summary_large_image" />

--- a/components/post-body/post-body.module.scss
+++ b/components/post-body/post-body.module.scss
@@ -148,7 +148,8 @@
     margin-bottom: 1rem;
     margin-top: 1rem;
 
-    ul, ol {
+    ul,
+    ol {
       margin-left: 1.25rem;
     }
   }

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -33,6 +33,7 @@ export default function BlogPost({ data }: PostsMain) {
         title={postHeaderData.title}
         description={postHeaderData.description}
         image={postHeaderData.imageUrl}
+        keywords={postHeaderData.keywords}
       />
 
       <div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,10 +2,12 @@ import { getAllPosts } from "../lib/api";
 import Layout from "../components/layout/layout";
 import FeaturedPosts from "../components/featured-posts/featured-posts";
 import generateRssFeed from "../lib/rss-feed";
+import MetaHead from "../components/meta-head/head";
 
 export default function BlogIndex({ data: allPost }: PostsPreview) {
   return (
     <Layout showCategories>
+      <MetaHead />
       <FeaturedPosts posts={allPost} />
     </Layout>
   );


### PR DESCRIPTION
Why:
 - The `Layout` component was duplicating meta tags because it had an extra `MetaHead` component as a child.
 - Keywords set on Sanity weren't being used.

How:
 - Removing the call of `MetaHead` inside the `Layout` component and using it directly inside `BlogIndex`, as it was the only place that didn't have it directly set.
 - Use the keywords set on Sanity for each post, otherwise, it uses the blog's default ones.